### PR TITLE
correction erreur js sur l'enregistrement des coordonnées de la fenêtre

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,18 +1,11 @@
-const setupEvents = require('./installers/setupEvents');
 const electron = require('electron');
 const path = require('path');
 const {app, BrowserWindow, shell, Menu, Tray} = electron;
 const gotTheLock = app.requestSingleInstanceLock();
-const {dialog} = require('electron');
 const settings = require('electron-settings');
 
 let messenger;
 let tray = null
-
-// squirrel installation méthode
-if (setupEvents.handleSquirrelEvent()) {
-    return;
-};
 
 // méthode single instance
 if (!gotTheLock){
@@ -50,7 +43,19 @@ app.on('ready', function(){
 
     tray = new Tray(path.join(__dirname, "/static/img/mess.ico"))
     const contextMenu = new Menu.buildFromTemplate([
-        { label: "Quitter NYM", click() { messenger.destroy() }}
+        { label: "Quitter NYM", click() { 
+            position = messenger.getPosition();
+            messengerSize = messenger.getSize();
+            settings.set('position', {
+                x: position[0],
+                y: position[1]
+            });
+            settings.set('windowsSize', {
+                width: messengerSize[0],
+                height: messengerSize[1]
+            })
+            console.log(messengerSize)
+            messenger.destroy() }}
     ]);
     tray.setToolTip('Not Your Messenger');
     tray.setContextMenu(contextMenu)
@@ -67,21 +72,23 @@ app.on('ready', function(){
         positiony = settings.get('position.y');
         winWidth = settings.get('windowsSize.width');
         winHeight = settings.get('windowsSize.height');
-        messenger.show();
-        messenger.setPosition(positionx, positiony);
-        messenger.setSize(winWidth, winHeight);
+        if (settings.has('position.x')){
+            messenger.show();
+            messenger.restore();
+            messenger.setPosition(positionx, positiony);
+            messenger.setSize(winWidth, winHeight);
+        } else {
+            messenger.show();
+            messenger.restore();
+        };
     });
 
     // attrappe l'ouverture de lien et l'ouvre dans le navigateur par défaut
     app.on('web-contents-created', (e, contents) => {
         if (contents.getType() == 'webview') {
             contents.on('new-window', (e, url) => {
-                if (url=='http://messenger.com/') {
-                    messenger.open();
-                } else {
-                    e.preventDefault();
-                    shell.openExternal(url);
-                };
+                e.preventDefault();
+                shell.openExternal(url);
             });
         };
     });
@@ -89,29 +96,5 @@ app.on('ready', function(){
 // fonctionnalités
     // désactive le menu et affiche l'url messenger
     messenger.loadFile("./template/main.html");
-    messenger.once('focus', () => messenger.flashFrame(false));
-    messenger.flashFrame(true);
-
-    // attrape l'event close et cache la fenêtre pour fermer l'application
-    messenger.on('close', function (event){
-
-        // enregistre la dernière position et la dernière taille de la fenêtre
-        position = messenger.getPosition();
-        messengerSize = messenger.getSize();
-        settings.set('position', {
-            x: position[0],
-            y: position[1]
-        });
-        settings.set('windowsSize', {
-            width: messengerSize[0],
-            height: messengerSize[1]
-        })
-
-        event.preventDefault();
-        messenger.minimize();
-    });
-
-    // fonctionnalité taskbar
-    // flash...
 
 })

--- a/static/loading.css
+++ b/static/loading.css
@@ -59,16 +59,12 @@ svg {
 	color: white !important;
 }
 
-._z4_ {
-}
-
 ._5i_d {
 	background-color: rgba(14, 14, 14, 0.719) !important;
 }
 
 ._hh7  {
 	color: white !important;
-
 }
 
 ._hh7 a {


### PR DESCRIPTION
- problème à l'ouverture de l'application qui n'avait pas de coordonnée à charger, condition pour charger la fenêtre centrer à la première ouverture. 

- problème sur les coordonnées qui ne s'enregistrais car l'event n'était plus existant. correction de l'évent sur le click du bouton fermer sur la tray.